### PR TITLE
Fix banner issue in editor

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,6 +29,12 @@ class CustomTLPPlugin extends Plugin {
       return;
     }
 
+    // Check if the container is an editor
+    if (!activeLeaf.view.containerEl.classList.contains('workspace-leaf-content')) {
+      this.clearTLPBanner();
+      return;
+    }
+
     const activeFile = this.app.workspace.getActiveFile();
     if (!activeFile) {
       this.clearTLPBanner();
@@ -53,7 +59,7 @@ class CustomTLPPlugin extends Plugin {
 
   clearTLPBanner() {
     document.body.classList.remove('tlp-active');
-    document.querySelectorAll('.tlp-banner').forEach(el => el.remove());
+    document.querySelectorAll('.workspace-leaf-content .tlp-banner').forEach(el => el.remove());
   }
 }
 


### PR DESCRIPTION
Fixes #1

Restrict the banner to the editor container when switching focus.

* Add a check in `main.js` to ensure the banner is only added to the editor container.
* Modify the `updateTLPBanner` method to verify if the `activeLeaf.view.containerEl` is an editor.
* Update the `clearTLPBanner` method to remove the banner only from the editor container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/4rr0wx/tlp-obsidian/issues/1?shareId=0119a447-c6a1-4bef-b761-8fb1d3146fdb).